### PR TITLE
 Sanitize input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ simple-server-healthcheck
 
 Add bare minimum features:
   1. Script Utility (meta)
-      - [ ] Sanitize input parameters
+      - [ ] Make connection attempt to provided list of servers
       - [ ] Parse timestamp from provided HTML at /health endpoint
       - [ ] An unreachable server is a bad server
       - [ ] Provide json array output
@@ -71,6 +71,7 @@ Add extra features:
 
 Done:
   1. Script Utility (meta)
+      - [X] Sanitize input parameters
       - [X] See if TDD is viable (not right now)
       - [X] Make it a [`thor`](https://github.com/erikhuda/thor) CLI app
   1. Development Support

--- a/lib/simple-server-healthcheck/cli.rb
+++ b/lib/simple-server-healthcheck/cli.rb
@@ -1,12 +1,35 @@
 require 'thor'
-require 'simple-server-healthcheck/version'
 
 module SimpleServerHealthcheck
   class CLI < Thor
-    desc 'hello NAME', 'say hello to NAME'
-    option :name, default: 'World', type: :string, required: false
-    def hello(name = 'World')
-      @stdout.puts "Hello, #{name}. Welcome to simple-server-healthcheck"
+    desc 'health', 'get health of SERVERS less than AGE'
+    long_desc <<-LONGDESC
+      Get the health information for a list of servers.
+      Server arguments should be in host:port format (e.g. server-1.example.com:8080, server-2.example.com:7070)
+      Each server is expected to have an available '/health' endpoint that responds with predefined HTML containing a "Last Updated" timestamp.
+      A server is defined to be healthy if and only its "Last Updated" timestamp is less than AGE minutes old.
+      Command is set to timeout after 5 minutes if unable to complete in that amount of time.
+    LONGDESC
+    option :age, type: :numeric, required: true
+    option :servers, type: :array, required: true
+    def health
+      @age = options[:age]
+      @servers = options[:servers]
+
+      check_hostname_port
+    end
+
+    private
+
+    attr_reader :age, :servers
+
+    def check_hostname_port
+      regex = /[^\:]+:[0-9]{2,5}/
+      servers.each do |server|
+        unless regex =~ server
+          raise "#{server} should include a colon followed by a port number"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Use Thor's argument parsing to parse command line arguments.

At present here is what we're enforcing:

```
option :age, type: :numeric, required: true
option :servers, type: :array, required: true
``` 

As well as ensuring that servers match this regex: `/[^\:]+:[0-9]{2,5}/`