### PR TITLE
Connection attempt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rspec'
+gem 'nokogiri'
 gem 'rubocop'
 gem 'thor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,25 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    diff-lcs (1.3)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     rainbow (3.0.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
     rubocop (0.55.0)
       parallel (~> 1.10)
       parser (>= 2.5)
@@ -36,7 +25,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rspec
+  nokogiri
   rubocop
   thor
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ simple-server-healthcheck
 Add bare minimum features:
   1. Script Utility (meta)
       - [ ] Parse timestamp from provided HTML at /health endpoint
-      - [ ] An unreachable server is a bad server
-      - [ ] Provide json array output
   1. Script Utility
       - [ ] Accept a list one or more server hosts/ports (server-1.example.com:8080, server-2.example.com:7070)
       - [ ] To check the health of a single server, query the server's `/health` endpoint,
@@ -70,6 +68,8 @@ Add extra features:
 
 Done:
   1. Script Utility (meta)
+      - [X] Provide json ~~array~~ output
+      - [X] An unreachable server is a bad server
       - [X] Make connection attempt to provided list of servers
       - [X] Sanitize input parameters
       - [X] See if TDD is viable (not right now)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ simple-server-healthcheck
 
 Add bare minimum features:
   1. Script Utility (meta)
-      - [ ] Make connection attempt to provided list of servers
       - [ ] Parse timestamp from provided HTML at /health endpoint
       - [ ] An unreachable server is a bad server
       - [ ] Provide json array output
@@ -71,6 +70,7 @@ Add extra features:
 
 Done:
   1. Script Utility (meta)
+      - [X] Make connection attempt to provided list of servers
       - [X] Sanitize input parameters
       - [X] See if TDD is viable (not right now)
       - [X] Make it a [`thor`](https://github.com/erikhuda/thor) CLI app

--- a/lib/simple-server-healthcheck/cli.rb
+++ b/lib/simple-server-healthcheck/cli.rb
@@ -36,10 +36,10 @@ module SimpleServerHealthcheck
     attr_reader :age, :health_list, :server, :servers
 
     def check_host_port
-      raise host_port_error unless SERVER_REGEX =~ @server
+      raise host_port_error_message unless SERVER_REGEX =~ @server
     end
 
-    def host_port_error
+    def host_port_error_message
       "#{@server} should be in the format HOST:PORT"
     end
 

--- a/lib/simple-server-healthcheck/cli.rb
+++ b/lib/simple-server-healthcheck/cli.rb
@@ -1,6 +1,10 @@
+require 'nokogiri'
+require 'open-uri'
 require 'thor'
 
 module SimpleServerHealthcheck
+  SERVER_REGEX = /[^\:]+:[0-9]{2,5}/
+  HEALTH_ENDPOINT = 'health'.freeze
   class CLI < Thor
     desc 'health', 'get health of SERVERS less than AGE'
     long_desc <<-LONGDESC
@@ -15,21 +19,38 @@ module SimpleServerHealthcheck
     def health
       @age = options[:age]
       @servers = options[:servers]
+      @server = ''
+      @health_list = {}
 
-      check_hostname_port
+      servers.each do |server|
+        @server = server
+        check_host_port
+        server_health
+      end
+
+      puts @health_list
     end
 
     private
 
-    attr_reader :age, :servers
+    attr_reader :age, :health_list, :server, :servers
 
-    def check_hostname_port
-      regex = /[^\:]+:[0-9]{2,5}/
-      servers.each do |server|
-        unless regex =~ server
-          raise "#{server} should include a colon followed by a port number"
-        end
-      end
+    def check_host_port
+      raise host_port_error unless SERVER_REGEX =~ @server
+    end
+
+    def host_port_error
+      "#{@server} should be in the format HOST:PORT"
+    end
+
+    def server_health
+      Nokogiri::HTML(open("http://#{@server}/#{HEALTH_ENDPOINT}"))
+    rescue Errno::ECONNREFUSED
+      update_health_list 'unhealthy'
+    end
+
+    def update_health_list(status)
+      @health_list[@server.to_s] = status
     end
   end
 end


### PR DESCRIPTION
Start attempting to connect to servers

* Remove `rspec` from the list of gems
* Use `nokogiri` to abstract the connection attempt and to parse the returned HTML ([example](http://ruby.bastardsbook.com/chapters/html-parsing))
* Add a data structure to track individual server health
* Add functionality to mark unreachable servers as unhealthy
 