### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Add extra features:
       - [ ] Put it in a container
   1. Integration Testing
       - [ ] Build a test rig
+      - [ ] Allow "Last Updated" timestamp test fixture to be programmatically generated
 
 Done:
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Add extra features:
       - [ ] Put it in a container
   1. Integration Testing
       - [ ] Build a test rig
+      - [ ] Make SERVER_REGEX more robust
       - [ ] Allow "Last Updated" timestamp test fixture to be programmatically generated
 
 Done:

--- a/lib/simple-server-healthcheck/cli.rb
+++ b/lib/simple-server-healthcheck/cli.rb
@@ -8,7 +8,7 @@ module SimpleServerHealthcheck
   SERVER_REGEX = /[^\:]+:[0-9]{2,5}/
   TIMEOUT_SECONDS = (5 * 60)
   class CLI < Thor
-    desc 'health', 'get health of SERVERS less than AGE'
+    desc 'health', 'get health of SERVERS based on AGE'
     long_desc <<-LONGDESC
       Get the health information for a list of servers.
       Server arguments should be in host:port format (e.g. server-1.example.com:8080, server-2.example.com:7070)

--- a/lib/simple-server-healthcheck/cli.rb
+++ b/lib/simple-server-healthcheck/cli.rb
@@ -19,7 +19,7 @@ module SimpleServerHealthcheck
     option :age, type: :numeric, required: true
     option :servers, type: :array, required: true
     def health
-      @age = options[:age]
+      @age = options[:age] * 60
       @servers = options[:servers]
       @server = ''
       @health_list = {}
@@ -64,7 +64,7 @@ module SimpleServerHealthcheck
 
     def server_health
       last_updated_timestamp = Time.parse(page).strftime('%s').to_i
-      if current_time.to_i - last_updated_timestamp.to_i < (@age * 60)
+      if current_time.to_i - last_updated_timestamp.to_i < @age
         update_health_list 'healthy'
       else
         update_health_list 'unhealthy'

--- a/lib/simple-server-healthcheck/cli.rb
+++ b/lib/simple-server-healthcheck/cli.rb
@@ -64,10 +64,10 @@ module SimpleServerHealthcheck
 
     def server_health
       last_updated_timestamp = Time.parse(page).strftime('%s').to_i
-      if current_time.to_i - last_updated_timestamp.to_i > (@age * 60)
-        update_health_list 'unhealthy'
-      else
+      if current_time.to_i - last_updated_timestamp.to_i < (@age * 60)
         update_health_list 'healthy'
+      else
+        update_health_list 'unhealthy'
       end
     rescue Errno::ECONNREFUSED, OpenURI::HTTPError
       update_health_list 'unhealthy'

--- a/test/health
+++ b/test/health
@@ -2,6 +2,6 @@
 <head><title>Server Health</title></head>
 <body>
 <h1>Server Status</h1>
-<p>Last Updated: <b>Mon Apr 23 02:01:00 2018 EDT</b></p>
+<p>Last Updated: <b>Mon Apr 23 07:40:00 2018 EDT</b></p>
 </body>
 </html>


### PR DESCRIPTION
* Fix command's short description
* Invert health logic for readability
* Convert `@age` instance to seconds at instantiation 
* Add TODO to allow timestamp in test fixture to be programmatically generated in the future
* Add TODO regarding making `SERVER_REGEX` more robust